### PR TITLE
fix button padding (closes #24)

### DIFF
--- a/mbta-rocks.css
+++ b/mbta-rocks.css
@@ -167,9 +167,14 @@ div.lines {
   overflow: hidden;
 }
 
-.btn-vote{
-  padding-left: 0.01rem;
+.card a.btn-vote{
+  padding-left: 0.5rem;
   padding-top: 0.01rem;
-  padding-right: 0.08rem;
+  padding-right: 0.7rem;
   padding-bottom: 0.01rem;
+  margin-right: 5px;
+}
+
+.card a.btn-vote i.left {
+  margin-right: 5px;
 }


### PR DESCRIPTION
Fits horizontally on iPhone 5S. On some narrower windows the buttons will end up on two rows, but that doesn't seem terrible.

![img_8010](https://cloud.githubusercontent.com/assets/934016/6322275/c970916e-bade-11e4-9d29-125cc3813187.PNG)
