### PR TITLE
use real routing (closes #21, #26)

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -12,3 +12,4 @@ d0minikk:materialize-meteor
 copleykj:livestamp
 u2622:persistent-session
 percolate:synced-cron
+iron:router

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -23,6 +23,14 @@ htmljs@1.0.3
 http@1.0.10
 id-map@1.0.2
 insecure@1.0.2
+iron:controller@1.0.7
+iron:core@1.0.7
+iron:dynamic-template@1.0.7
+iron:layout@1.0.7
+iron:location@1.0.7
+iron:middleware-stack@1.0.7
+iron:router@1.0.7
+iron:url@1.0.7
 jquery@1.11.3
 json@1.0.2
 launch-screen@1.0.1

--- a/mbta-rocks.css
+++ b/mbta-rocks.css
@@ -181,11 +181,6 @@ div.lines {
   font-size: 0.8em;
 }
 
-.noscroll {
-  position: relative;
-  overflow: hidden;
-}
-
 .card a.btn-vote{
   padding-left: 0.5rem;
   padding-top: 0.01rem;

--- a/mbta-rocks.html
+++ b/mbta-rocks.html
@@ -16,7 +16,9 @@
 </head>
 
 <body>
+</body>
 
+<template name="main">
   <div class="navbar-fixed">
     <nav>
       <div class="nav-wrapper grey darken-2">
@@ -62,10 +64,7 @@
   </div>
 
   {{> createEvent}}
-
-  {{> introModal}}
-
-</body>
+</template>
 
 <template name="createEvent">
   <div id="add-modal" class="modal">
@@ -148,7 +147,7 @@
   </div>
 </template>
 
-<template name="introModal">
+<template name="landing">
   <div id="intro-screen">
     <div class="intro-screen-content">
       <div class="logo">
@@ -166,8 +165,8 @@
         <li>Confirm them when you see the same thing.</li>
       </ul>
       <div class="collection lines">
-        <a href="#!" class="collection-item line-selector red-text" data-line="Red Line - Northbound">Red Line - Northbound (to Alewife)</a>
-        <a href="#!" class="collection-item line-selector red-text" data-line="Red Line - Southbound">Red Line - Southbound (to Ashmont)</a>
+        <a href="{{pathFor 'line.show' line='Red Line - Northbound'}}" class="collection-item line-selector red-text">Red Line - Northbound (to Alewife)</a>
+        <a href="{{pathFor 'line.show' line='Red Line - Southbound'}}" class="collection-item line-selector red-text">Red Line - Southbound (to Asmt/Btree)</a>
       </div>
       <div class="credits">
         Created by <a target="_blank" href="https://twitter.com/dave_lago">David Lago</a>, <a href="https://twitter.com/geoffreylitt" target="_blank">Geoffrey Litt</a>, and <a href="https://twitter.com/radhika1990">Radhika Malik</a> for the Code Across Boston 2015 hackathon.


### PR DESCRIPTION
Use iron-router to separate the landing page and
line viewing pages into real separate pages with
their own URLs.

This has several benefits:
- No more glitching with switching lines
- No more scrolling bug on landing page
- Refreshing on a line page doesn't take you back to landing page
- Transitions between line pages are much snappier
