### PR TITLE
Correct typos in GitHub branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ The site is built using Meteor.js and Materialize.css, and deployed on Heroku.
 
 We welcome contributions that would make this tool more useful for the Boston community -- whether it's adding support for more MBTA lines, or entire new features.
 
-Please create a Github issue if you have an idea. And if you're able to code a solution and open a pull request, even better!
+Please create a GitHub issue if you have an idea. And if you're able to code a solution and open a pull request, even better!

--- a/mbta-rocks.html
+++ b/mbta-rocks.html
@@ -181,7 +181,7 @@
         <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://mbta.ninja" data-text="Check out MBTA Ninja - Waze for the T" data-hashtags="mbta">Tweet</a>
       </div>
       <div class="credits">
-        Created by <a target="_blank" href="https://twitter.com/dave_lago">David Lago</a>, <a href="https://twitter.com/geoffreylitt" target="_blank">Geoffrey Litt</a>, and <a href="https://twitter.com/radhika1990" target="_blank">Radhika Malik</a> for the Code Across Boston 2015 hackathon. To request more line coverage or new features, <a href="http://twitter.com/home?status=@dave_lago @geoffreylitt @radhika1990 " target="_blank">tweet at us</a> or <a target="_blank" href="https://github.com/davidlago/mbta-ninja">contribute on Github</a>.
+        Created by <a target="_blank" href="https://twitter.com/dave_lago">David Lago</a>, <a href="https://twitter.com/geoffreylitt" target="_blank">Geoffrey Litt</a>, and <a href="https://twitter.com/radhika1990" target="_blank">Radhika Malik</a> for the Code Across Boston 2015 hackathon. To request more line coverage or new features, <a href="http://twitter.com/home?status=@dave_lago @geoffreylitt @radhika1990 " target="_blank">tweet at us</a> or <a target="_blank" href="https://github.com/davidlago/mbta-ninja">contribute on GitHub</a>.
       </div>
     </div>
   </div>


### PR DESCRIPTION
Change `Github` to `GitHub`.
