### PR TITLE
smaller layout

### DIFF
--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -43,23 +43,16 @@
 .back-button {
   float: left;
   overflow: hidden;
-  padding-top: 9px;
+  position: absolute;
   margin-left: 10px;
-  margin-right: 10px;
-}
-
-.back-button img {
-  height: 20px;
-  margin-right: 10px;
-  vertical-align: middle;
+  line-height: 44px;
 }
 
 .line-being-viewed {
   margin-top: 15px;
-  margin-right: 8px;
   text-align: center;
   width: 100%;
-  font-size: 20px;
+  font-size: 16px;
 }
 
 .top-panel {
@@ -71,14 +64,15 @@
 }
 
 img.top-panel-ninja {
-  height: 50px;
+  height: 40px;
   float: left;
 }
 
 .top-panel-text {
   float: left;
-  margin-top: 14px;
-  font-size: 18px;
+  margin-left: 5px;
+  line-height: 40px;
+  font-size: 16px;
 }
 
 .main-content {
@@ -159,22 +153,31 @@ select {
   padding: 10px;
 }
 
+.logo {
+  overflow: hidden;
+  width: 250px;
+  margin: 0 auto;
+  text-align: left;
+}
+
 .ninja-logo {
-  height: 100px;
-  width: 100px;
+  height: 64px;
+  width: 64px;
   margin: 0 auto 10px auto;
+  float: left;
 }
 
 h1.app-title {
-  font-size: 40px;
+  font-size: 32px;
   margin: 0 0 5px 0;
   line-height: 1.2em;
 }
 
 h2.app-subtitle {
-  font-size: 24px;
+  font-size: 18px;
   margin: 0 0 10px 0;
   line-height: 1.2em;
+  font-style: italic;
 }
 
 div.lines {

--- a/client/templates/landing.html
+++ b/client/templates/landing.html
@@ -4,13 +4,13 @@
     <div class="intro-screen-content">
       <div class="logo">
         <img class="ninja-logo" src="/images/ninja.png" />
+        <h1 class="app-title">
+          MBTA Ninja
+        </h1>
+        <h2 class="app-subtitle">
+          Waze for the T
+        </h2>
       </div>
-      <h1 class="app-title">
-        MBTA Ninja
-      </h1>
-      <h2 class="app-subtitle">
-        Waze for the T
-      </h2>
       <ul>
         <li>No more guessing what "minor delays" means.</li>
         <li>Get realtime updates from fellow T riders.</li>

--- a/client/templates/main.html
+++ b/client/templates/main.html
@@ -4,8 +4,7 @@
       <div class="nav-wrapper grey darken-2">
         <div class="back-button">
           <a href="/">
-            &lt;
-            <img src="/images/ninja.png" />
+            &lsaquo; Back
           </a>
         </div>
         <div class="line-being-viewed">


### PR DESCRIPTION
fixing this PR: https://github.com/davidlago/mbta-ninja/pull/64

"I made some small edits to the app's layout - specifically the homepage (logo smaller re: #39, added some color to the MBTA) and to the nav bar on line pages (clearer back button, smaller text in a few places). Obviously the visual edits are somewhat subjective, but I think these are good improvements for the usability. On iPhone 4 sized screens, almost all of the lines were being pushed below the fold because of the large title, subtitle, and logo."
