### PR TITLE
Fixed upvote weight-capping

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -104,7 +104,8 @@ Meteor.methods({
   upvoteReport: function(docId) {
     Reports.update(docId, {$inc: {votes: 1}});
     // Cap weight to maxWeight
-    var newWeight = this.weight + upvoteWeight;
+    doc = Reports.findOne({_id: docId});
+    var newWeight = doc.weight + upvoteWeight;
     if (newWeight > maxWeight)
       newWeight = maxWeight;
     Reports.update(docId,
@@ -113,6 +114,6 @@ Meteor.methods({
   downvoteReport: function(docId) {
     Reports.update(docId, {$inc: {clears: 1}});
     Reports.update(docId, {$set: {lastClearedAt: new Date()}});
-    Reports.update(docId, {$inc: {weight: downvoteWeight}})
+    Reports.update(docId, {$inc: {weight: downvoteWeight}});
   }
 });


### PR DESCRIPTION
This was a weird spurious error when somebody upvoting an alert could
delete it. The problem was that we didn't calculate the current weight
correctly in one of the cases, and it resulted in the new weight being
set as NaN. I don't know if this was the sole culprit for this issue,
but it was certainly causing upvotes to expire reports.
