### PR TITLE
Add open api

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,4 +1,19 @@
-Meteor.startup(function() {});
+Meteor.startup(function() {
+  Restivus.configure({
+    useAuth: false,
+    prettyJson:true
+  });
+
+  
+  Restivus.addRoute('reports',{authRequired: false},{ 
+      get: function(){
+      //GET api/reports
+      //Gives you the current list of active reports.
+      var reports = Reports.find({expired: false}).fetch();
+      return {statusCode:200, body:{data: reports}};
+    }
+  });
+});
 
 // Task to expire old reports. It checks every minute to see if there are
 // tasks reported/confirmed more than 30 minutes ago.


### PR DESCRIPTION
First round at a open API this one just exposes active reports right now.

People can query it based by doing a GET request against

`/api/reports/`

example would be `curl -X GET localhost:3000/api/reports`

Should solve #46 for now, though we should get feedback on the design/ what people might be looking to query. We should also think about looking into using a limit of results and an offset of results.
