### PR TITLE
Add visual cue on landing page for if line has any alerts at all

### DIFF
--- a/client/templates/line.html
+++ b/client/templates/line.html
@@ -1,9 +1,19 @@
 <template name="line">
   <li class="line">
-  <div class="collapsible-header"><i class="mdi-maps-directions-{{type}} subway-icon {{color}}"></i>{{line}}<span class="secondary-content"><i class="mdi-navigation-expand-more grey-text lighten-2"></i></span></div>
+  <div class="collapsible-header"><i class="mdi-maps-directions-{{type}} subway-icon {{color}}"></i>{{line}}
+  <span class="secondary-content">
+    {{#if lineAlerts}}
+      <i class="mdi-alert-warning red-text"></i>
+    {{/if}}
+    <i class="mdi-navigation-expand-more grey-text lighten-2"></i></span>
+  </div>
     {{#each directions}}
       <div class="collapsible-body">
-        <a href="{{pathFor 'line.show' line=path type=../type}}">{{direction}}<span class="secondary-content"><i class="mdi-navigation-chevron-right black-text"></i></span></a>
+        <a href="{{pathFor 'line.show' line=path type=../type}}">{{direction}}
+        {{#if numberReports}}
+          <i class="mdi-alert-warning red-text"></i>
+        {{/if}}
+        <span class="secondary-content"><i class="mdi-navigation-chevron-right black-text"></i></span></a>
       </div>
     {{/each}}
   </li>

--- a/client/templates/line.js
+++ b/client/templates/line.js
@@ -1,0 +1,23 @@
+Meteor.subscribe('reports');
+
+Template.line.helpers({
+  numberReports: function() {
+    return Reports.find({
+      expired: false,
+      line: this.path
+    }).count();
+  },
+  lineAlerts: function(){
+    var directions = this.directions;
+    for (var i = 0; i < directions.length; i++) {
+      var path = directions[i].path
+      var path_reports = Reports.find({
+        expired: false,
+        line: path
+      }).count();
+      if (path_reports) {
+        return true
+      }
+    };
+  }
+});


### PR DESCRIPTION
We added this feature to septa.ninja and thought it might be useful for mbta.ninja. Users don't have to click/tap through to see whether the line they are interested in has any alerts. By looking at the front page, they know their line is running normally unless there is an alert icon. 

![screen shot 2015-06-06 at 7 08 35 pm](https://cloud.githubusercontent.com/assets/9420529/8021861/8efe4c4a-0c7f-11e5-8e3b-32dfe80ca619.png)
